### PR TITLE
upgrade to php7 compatibility as used in dragonbe/vies package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+charset = utf-8
+max_line_length = 160
+indent_size = 4
+indent_style = space
+end_of_line = LF
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 php:
-  - '5.5'
-  - '5.6'
   - '7.0'
   - '7.1'
 before_script:

--- a/README.md
+++ b/README.md
@@ -11,3 +11,5 @@ Contains a constraint and validator to use VAT validation in your forms
 This project is on [Packagist!](https://packagist.org/packages/sandwich/vies-bundle)
 
 To install the latest stable version use composer require sandwich/vies-bundle.
+
+Contributions are welcome please use the Symfony coding style with some small exceptions (see phpcs.xml)

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,18 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
-        "dragonbe/vies": "1.0.6",
+        "php": ">=7.0",
+        "dragonbe/vies": "^1.0",
         "symfony/http-kernel": "^2.8",
         "symfony/symfony": "^2.8",
         "symfony/validator": "^2.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "roave/security-advisories": "dev-master",
+        "phpunit/phpunit": "~5.7",
+        "escapestudios/symfony2-coding-standard": "3.0",
+        "phpmd/phpmd": "^2.6",
+        "squizlabs/php_codesniffer": "3.1.*"
     },
     "autoload": {
         "psr-4": { "Sandwich\\ViesBundle\\": "src" }
@@ -30,9 +34,6 @@
     },
     "config": {
         "vendor-dir": "vendor",
-        "sort-packages": true,
-        "platform": {
-            "php": "5.5"
-        }
+        "sort-packages": true
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset name="MyOnlineStore">
+    <description>ViewBundle coding standard.</description>
+
+    <file>./</file>
+
+    <!-- Include the whole Symfony2 standard -->
+    <rule ref="vendor/escapestudios/symfony2-coding-standard/Symfony/ruleset.xml"/>
+
+    <rule ref="Symfony">
+        <exclude name="Symfony.Commenting.ClassComment.Missing"/>
+        <exclude name="Symfony.Commenting.FunctionComment.Missing"/>
+        <exclude name="Symfony.Commenting.License.Warning"/>
+        <exclude name="Symfony.Functions.Arguments.Invalid"/>
+    </rule>
+
+    <!-- The soft limit on line length MUST be 120 characters; automated style checkers MUST warn but MUST NOT error at the soft limit. -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="120"/>
+            <property name="absoluteLineLimit" value="0"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<ruleset name="PHPMD rule set"
+         xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+    <description>The MyOnlineStore coding standard.</description>
+
+    <rule ref="rulesets/codesize.xml"/>
+    <rule ref="rulesets/design.xml">
+        <exclude name="CouplingBetweenObjects"/>
+    </rule>
+    <rule ref="rulesets/naming.xml">
+        <exclude name="ShortVariable"/>
+        <exclude name="LongVariable"/>
+    </rule>
+    <rule ref="rulesets/unusedcode.xml">
+        <exclude name="UnusedPrivateField"/>
+        <exclude name="UnusedLocalVariable"/>
+    </rule>
+
+    <rule ref="rulesets/naming.xml/ShortVariable">
+        <properties>
+            <property name="minimum" value="3"/>
+            <property name="exceptions" value="id"/>
+        </properties>
+    </rule>
+
+    <rule ref="rulesets/design.xml/CouplingBetweenObjects">
+        <properties>
+            <property name="minimum" value="20"/>
+        </properties>
+    </rule>
+
+    <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable">
+        <properties>
+            <property name="allow-unused-foreach-variables" value="true"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/src/Validator/Constraint/VatNumber.php
+++ b/src/Validator/Constraint/VatNumber.php
@@ -20,9 +20,17 @@ final class VatNumber extends Constraint
     public $message = 'This is not a valid %format% vat number.';
 
     /**
+     * @return string
+     */
+    public function getFormat(): string
+    {
+        return $this->format;
+    }
+
+    /**
      * @inheritDoc
      */
-    public function validatedBy()
+    public function validatedBy(): string
     {
         return VatNumberValidator::class;
     }

--- a/src/Validator/Constraint/VatNumberValidator.php
+++ b/src/Validator/Constraint/VatNumberValidator.php
@@ -32,18 +32,20 @@ final class VatNumberValidator extends ConstraintValidator
             return;
         }
 
-        if (!$this->viesApi->getHeartBeat()) {
+        if (!$constraint instanceof VatNumber) {
+            return;
+        }
+
+        if (!$this->viesApi->getHeartBeat()->isAlive()) {
             //VIES service is not available
             return;
         }
 
-        $format = $constraint->format;
+        $format = $constraint->getFormat();
         $isValid = false;
 
         try {
-            $result = $this->viesApi->validateVat($format, str_replace($format, '', $value));
-
-            $isValid = $result->isValid();
+            $isValid = $this->viesApi->validateVat($format, str_replace($format, '', $value))->isValid();
         } catch (ViesServiceException $exception) {
             //There is probably a temporary problem with back-end VIES service
             return;

--- a/tests/Validator/Constraint/VatNumberTest.php
+++ b/tests/Validator/Constraint/VatNumberTest.php
@@ -19,7 +19,7 @@ final class VatNumberTest extends \PHPUnit_Framework_TestCase
 
     public function testContainsCorrectInitialFormat()
     {
-        self::assertSame('NL', $this->constraint->format);
+        self::assertSame('NL', $this->constraint->getFormat());
     }
 
     public function testContainsCorrectMessage()


### PR DESCRIPTION
version 1.0.7 en 1.0.8 of dragonbe/vies were only intended to be used with php7.0 this PR upgrades the code to be compatible with php7. 