### PR TITLE
Do not allow to pass vat number with "0"

### DIFF
--- a/src/Validator/Constraint/VatNumberValidator.php
+++ b/src/Validator/Constraint/VatNumberValidator.php
@@ -29,7 +29,7 @@ final class VatNumberValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint): void
     {
-        if (empty($value)) {
+        if ($value === '') {
             return;
         }
 


### PR DESCRIPTION
Hello! Construct empty is dangerous. One of our client visitors inserted "0" as a VAT number, but the validator didn't check it.